### PR TITLE
fix: benchpress macro in multiple files causes duplicate symbols link error

### DIFF
--- a/src/benchpress/benchpress.hpp
+++ b/src/benchpress/benchpress.hpp
@@ -405,6 +405,7 @@ private:
     }
 };
 
+#ifdef BENCHPRESS_CONFIG_MAIN
 /*
  * The run_benchmarks function will run the registered benchmarks.
  */
@@ -419,6 +420,7 @@ void run_benchmarks(const options& opts) {
         }
     }
 }
+#endif
 
 } // namespace benchpress
 


### PR DESCRIPTION
with BENCHPRESS_CONFIG_MAIN only defined in one file
